### PR TITLE
stricter password requirements

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -119,7 +119,7 @@ module Devise
 
   # Range validation for password length
   mattr_accessor :password_length
-  @@password_length = 6..128
+  @@password_length = 10..128
 
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -35,6 +35,7 @@ module Devise
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
           validates_length_of       :password, within: password_length, allow_blank: true
+          validate :password_security, if: :password_required?
         end
       end
 
@@ -58,6 +59,12 @@ module Devise
 
       def email_required?
         true
+      end
+
+      def password_security(password)
+        unless password =~ /[A-Z]/ || unless password =~ /[a-z]/ || unless password =~ /\d/
+          errors[:password].add("is not secure.")
+        end
       end
 
       module ClassMethods

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -80,16 +80,22 @@ class ValidatableTest < ActiveSupport::TestCase
     assert user.errors.added?(:password_confirmation, :confirmation, attribute: "Password")
   end
 
-  test 'should require a password with minimum of 7 characters' do
+  test 'should require a password with minimum of 10 characters' do
     user = new_user(password: '12345', password_confirmation: '12345')
     assert user.invalid?
-    assert_equal 'is too short (minimum is 7 characters)', user.errors[:password].join
+    assert_equal 'is too short (minimum is 10 characters)', user.errors[:password].join
   end
 
   test 'should require a password with maximum of 72 characters long' do
     user = new_user(password: 'x'*73, password_confirmation: 'x'*73)
     assert user.invalid?
     assert_equal 'is too long (maximum is 72 characters)', user.errors[:password].join
+  end
+
+  test 'should require a password with an uppercase, lowercase letter, and a number' do
+    user = new_user(password: 'abcdefghijk', password_confirmation: 'abcdefghijk')
+    assert user.invalid?
+    assert_equal 'is not secure', user.errors[:password].join
   end
 
   test 'should not require password length when it\'s not changed' do


### PR DESCRIPTION
This PR is in response to the issue [here](https://github.com/heartcombo/devise/issues/5591). 

It increases the default password length to 10 characters as opposed to the 6 characters now & it requires that a password has an uppercase letter, lowercase letter and number. 

The intention of this is to boost default security level within Devise. 